### PR TITLE
Fixed pod error as reported by CPANTS.

### DIFF
--- a/IDEtabFrame.pm
+++ b/IDEtabFrame.pm
@@ -176,6 +176,7 @@ is used as a "dropbox" where the source can put a object in this hash, key'ed by
 name is passed to the target (i.e. the drop location). The target can use the string to lookup the
 real object in this hash.
 
+=back
 
 =head1 Methods
 


### PR DESCRIPTION
Hi @asb-capfan 

Please review the PR.
https://cpants.cpanauthors.org/release/CAC/Tk-IDElayout-0.34

         no_pod_errors
         Remove the POD errors. You can check for POD errors automatically by including Test::Pod to your test suite.

         Error: *** ERROR: You forgot a '=back' before '=head1' at line 180 in file Tk-IDElayout-
         0.34/IDEtabFrame.pm

Many Thanks.

Best Regards,
Mohammad S Anwar